### PR TITLE
feat: add mainnet (chain 626) support via NETWORK toggle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,5 +16,5 @@ AGREEMENT_ADDRESS=
 # Set to your wallet address (same as SENDER_ADDRESS for this tutorial)
 RECOVERY_ADDRESS=
 
-# ── Testnet Attack Registry address ───────────────────────────────────────────
-ATTACK_REGISTRY=0x22134e878c409a0Eab7259d873b38e26Ca966d3C
+# Note: the attack registry address is no longer needed here — `just check-state`
+# resolves it per network (testnet vs NETWORK=mainnet) automatically.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,18 @@ A starter repo for interacting with the Battlechain Safe Harbor protocol. Includ
 | BattleChain         | 626      | https://mainnet.battlechain.com  |
 | BattleChain Testnet | 627      | https://testnet.battlechain.com  |
 
-The Safe Harbor core contracts (registry, agreement factory, attack registry), CreateX, and the Safe contract suite are deployed on both networks, and both have a block explorer with contract verification: [mainnet](https://explorer.mainnet.battlechain.com/) and [testnet](https://explorer.testnet.battlechain.com/). The flows in this repo target BattleChain Testnet, since the mock dependencies (such as the permissionless `MockRegistryModerator` used to approve attack mode) are testnet-only.
+The Safe Harbor core contracts (registry, agreement factory, attack registry), CreateX, and the Safe contract suite are deployed on both networks, and both have a block explorer with contract verification: [mainnet](https://explorer.mainnet.battlechain.com/) and [testnet](https://explorer.testnet.battlechain.com/).
+
+The recipes default to **BattleChain Testnet**. To target **Mainnet**, prefix any recipe with `NETWORK=mainnet`:
+
+```bash
+just setup                  # testnet (default)
+NETWORK=mainnet just setup  # mainnet (chain 626)
+```
+
+`NETWORK` switches the RPC, chain id, attack-registry address, and verification endpoint automatically.
+
+**Mainnet differs from testnet at the approval step.** The permissionless `MockRegistryModerator` used by `just approve-attack-mode` is **testnet-only** — on mainnet `approve-attack-mode` refuses to run. Instead, after `NETWORK=mainnet just request-attack-mode`, an access-controlled registry-moderator multisig must approve the request before the agreement reaches `UNDER_ATTACK` and you can run `NETWORK=mainnet just attack`.
 
 # Getting Started
 
@@ -64,12 +75,13 @@ just request-attack-mode
 
 # Step 3b: Approve the request via the permissionless MockRegistryModerator (testnet only)
 just approve-attack-mode
+# On mainnet, skip this step — a registry-moderator multisig approves the request instead.
 ```
 
 ## Whitehat Role
 
 ```bash
-# Step 4: Execute the attack (requires DAO approval first)
+# Step 4: Execute the attack (requires DAO/moderator approval first)
 just attack
 ```
 

--- a/justfile
+++ b/justfile
@@ -2,11 +2,19 @@ set dotenv-load
 
 import "lib/battlechain-lib/battlechain.just"
 
-# Recipes target BattleChain Testnet (chain 627): the mock dependencies (e.g. the permissionless
-# MockRegistryModerator) are testnet-only. Verification and block explorers exist on both networks.
-# The Safe Harbor contracts are also deployed on mainnet (chain 626, https://mainnet.battlechain.com).
-RPC    := "https://testnet.battlechain.com"
+# Network selection (from battlechain.just): defaults to Testnet (chain 627). Target
+# Mainnet (chain 626) by prefixing any recipe with NETWORK=mainnet, e.g.
+#   NETWORK=mainnet just setup
+# RPC, chain id, and verify flags all follow NETWORK via bc-rpc / bc-chain-id / bc-verify-flags.
+#
+# Caveat: the permissionless MockRegistryModerator (used by `approve-attack-mode`) is testnet-only.
+# On mainnet the registry moderator is access-controlled, so attack-mode approval happens off this
+# repo (a moderator multisig). `approve-attack-mode` therefore refuses to run on mainnet.
+RPC    := bc-rpc
 ACCT   := "battlechain"
+
+# Attack registry address per network (from battlechain-lib BCConfig.sol), used by `check-state`.
+ATTACK_REGISTRY_ADDR := if NETWORK == "mainnet" { "0x24876e481eC7198CAC95af739Df2a852CE65A415" } else { "0x22134e878c409a0Eab7259d873b38e26Ca966d3C" }
 
 # ── Protocol role ──────────────────────────────────────────────────────────────
 
@@ -22,8 +30,17 @@ create-agreement:
 request-attack-mode:
     forge script script/RequestAttackMode.s.sol --rpc-url {{RPC}} --broadcast -vvv --account {{ACCT}} --sender $SENDER_ADDRESS --skip-simulation
 
-# Step 3b: Approve the request via the permissionless MockRegistryModerator (testnet only, requires AGREEMENT_ADDRESS in .env)
+# Step 3b: Approve the request via the permissionless MockRegistryModerator (TESTNET ONLY, requires AGREEMENT_ADDRESS in .env)
 approve-attack-mode:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ "${NETWORK:-testnet}" = "mainnet" ]; then
+        echo "approve-attack-mode is testnet-only."
+        echo "On mainnet the registry moderator is access-controlled (a moderator multisig), so there is"
+        echo "no self-service approval. After 'NETWORK=mainnet just request-attack-mode', ask a moderator"
+        echo "multisig signer to approve the request; then run 'NETWORK=mainnet just attack'."
+        exit 1
+    fi
     forge script script/ApproveAttackMode.s.sol --rpc-url {{RPC}} --broadcast -vvv --account {{ACCT}} --sender $SENDER_ADDRESS --skip-simulation
 
 # ── Whitehat role ──────────────────────────────────────────────────────────────
@@ -62,9 +79,9 @@ verify-setup:
 generate-key:
     cast wallet import battlechain --private-key 0x$(openssl rand -hex 32)
 
-# Check agreement state (2=ATTACK_REQUESTED, 3=UNDER_ATTACK)
+# Check agreement state (2=ATTACK_REQUESTED, 3=UNDER_ATTACK, 5=PRODUCTION)
 check-state:
-    cast call $ATTACK_REGISTRY "getAgreementState(address)(uint8)" $AGREEMENT_ADDRESS \
+    cast call {{ATTACK_REGISTRY_ADDR}} "getAgreementState(address)(uint8)" $AGREEMENT_ADDRESS \
         --rpc-url {{RPC}}
 
 build:


### PR DESCRIPTION
## Summary

Make the starter flow network-aware so it can target **BattleChain Mainnet (chain 626)** in addition to Testnet (627). Prefix any recipe with `NETWORK=mainnet`:

```bash
just setup                  # testnet (default)
NETWORK=mainnet just setup  # mainnet
```

`NETWORK` drives the RPC, chain id, attack-registry address, and verify endpoint via `bc-rpc`/`bc-chain-id`/`bc-verify-flags` (already defined in `battlechain-lib/battlechain.just`).

## Changes

- **`justfile`**
  - `RPC := bc-rpc` (was hardcoded to testnet)
  - `approve-attack-mode` **hard-fails on mainnet** — the permissionless `MockRegistryModerator` is testnet-only; on mainnet, approval is gated behind an access-controlled registry-moderator multisig (off-repo), so self-service approval doesn't exist
  - `check-state` resolves the attack-registry address per network instead of reading `ATTACK_REGISTRY` from `.env`
- **`README.md`** — documents the `NETWORK=mainnet` toggle and the mainnet approval difference
- **`.env.example`** — drops the now-unneeded `ATTACK_REGISTRY` var

Keystore-based signing (`--account battlechain`) is unchanged.

## Verification

Ran the full flow end-to-end on **mainnet (626)**: `setup` → `create-agreement` → `request-attack-mode` → (moderator multisig approval → `UNDER_ATTACK`) → `attack` (vault drained 1000 → 0). The `NETWORK=mainnet` toggle, the `approve-attack-mode` guard, and per-network `check-state` were all exercised live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)