### PR TITLE
fix: exclude attacker seed from bounty base

### DIFF
--- a/script/Attack.s.sol
+++ b/script/Attack.s.sol
@@ -7,7 +7,8 @@ import {Exploit} from "../src/Exploit.sol";
 
 /// @notice Step 5 (Whitehat): Deploy the Exploit — a SINGLE transaction that approves
 /// attack mode (via the permissionless testnet moderator) and drains the vault via
-/// reentrancy, then splits the proceeds per Safe Harbor terms (90% back, 10% bounty).
+/// reentrancy, then settles per Safe Harbor terms: the protocol's recovered funds are
+/// returned minus the 10% bounty, and the whitehat reclaims their seed deposit.
 ///
 /// Prerequisites — set in .env:
 ///   VAULT_ADDRESS, TOKEN_ADDRESS, RECOVERY_ADDRESS, AGREEMENT_ADDRESS
@@ -17,6 +18,7 @@ import {Exploit} from "../src/Exploit.sol";
 ///   just attack-browser    # your own wallet (MetaMask/Trezor)
 contract Attack is Script {
     address constant MOCK_REGISTRY_MODERATOR = 0x3DdA228A38b4d7438bBF5D5137c8D1090DcaF6bF;
+    uint256 constant BOUNTY_BPS = 1_000; // 10% — display only; keep in sync with Attacker.BOUNTY_BPS
 
     function run() external {
         address vault = vm.envAddress("VAULT_ADDRESS");
@@ -33,12 +35,18 @@ contract Attack is Script {
         vm.stopBroadcast();
 
         uint256 vaultAfter = IERC20(token).balanceOf(vault);
-        uint256 returned = IERC20(token).balanceOf(recovery);
+
+        // The whole vault is drained, so `vaultBefore` IS the protocol's recovered funds
+        // (the attacker's seed is reclaimed separately). The bounty is 10% of that. We
+        // derive the split from the rule rather than post-state balances because in this
+        // quickstart RECOVERY_ADDRESS and the deploying wallet are the same address.
+        uint256 recovered = vaultBefore;
+        uint256 bounty = (recovered * BOUNTY_BPS) / 10_000;
 
         console.log("\n--- Vault drained ---");
         console.log("Vault before:      ", vaultBefore / 1e18, "tokens");
         console.log("Vault after:       ", vaultAfter / 1e18, "tokens");
-        console.log("Returned to protocol:", returned / 1e18, "tokens");
-        console.log("(The 10%% bounty went to the wallet that deployed the Exploit.)");
+        console.log("Returned to protocol:", (recovered - bounty) / 1e18, "tokens");
+        console.log("Bounty kept (yours): ", bounty / 1e18, "tokens (plus your reclaimed seed)");
     }
 }

--- a/script/McpAttack.s.sol
+++ b/script/McpAttack.s.sol
@@ -12,6 +12,8 @@ import {Attacker} from "../src/Attacker.sol";
 ///
 /// Prerequisites — set in .env: SENDER_ADDRESS, TOKEN_ADDRESS, VAULT_ADDRESS, RECOVERY_ADDRESS
 contract McpAttack is Script {
+    uint256 constant BOUNTY_BPS = 1_000; // 10% — display only; keep in sync with Attacker.BOUNTY_BPS
+
     function run() external {
         address vault = vm.envAddress("VAULT_ADDRESS");
         address token = vm.envAddress("TOKEN_ADDRESS");
@@ -26,7 +28,14 @@ contract McpAttack is Script {
         vm.stopBroadcast();
 
         uint256 vaultAfter = IERC20(token).balanceOf(vault);
+
+        // `vaultBefore` is the protocol's recovered funds (the attacker's seed is
+        // reclaimed separately); the bounty is 10% of that.
+        uint256 recovered = vaultBefore;
+        uint256 bounty = (recovered * BOUNTY_BPS) / 10_000;
+
         console.log("Vault after:", vaultAfter / 1e18, "tokens (drained)");
-        console.log("Returned to protocol:", IERC20(token).balanceOf(recovery) / 1e18, "tokens");
+        console.log("Returned to protocol:", (recovered - bounty) / 1e18, "tokens");
+        console.log("Bounty kept (yours):", bounty / 1e18, "tokens (plus your reclaimed seed)");
     }
 }

--- a/src/Attacker.sol
+++ b/src/Attacker.sol
@@ -85,11 +85,14 @@ contract Attacker {
         VAULT.withdrawAll();
 
         // ── Safe Harbor fund distribution ──────────────────────────────────
-        // Return recovered funds to the protocol, keeping only the agreed bounty.
+        // The drained balance includes our own SEED_AMOUNT, so the bounty is taken on
+        // the PROTOCOL's recovered funds only — we don't earn a bounty on our own seed.
+        // The protocol gets its share back; we keep the bounty plus our reclaimed seed.
         uint256 total = TOKEN.balanceOf(address(this));
-        uint256 bounty = (total * BOUNTY_BPS) / 10_000;
+        uint256 recovered = total - SEED_AMOUNT;
+        uint256 bounty = (recovered * BOUNTY_BPS) / 10_000;
 
-        TOKEN.transfer(RECOVERY_ADDRESS, total - bounty);
-        TOKEN.transfer(BENEFICIARY, bounty);
+        TOKEN.transfer(RECOVERY_ADDRESS, recovered - bounty);
+        TOKEN.transfer(BENEFICIARY, bounty + SEED_AMOUNT);
     }
 }

--- a/test/ReentrancyTest.t.sol
+++ b/test/ReentrancyTest.t.sol
@@ -28,9 +28,12 @@ contract ReentrancyTest is Test {
         vm.prank(whitehat);
         new Exploit(address(vault), recovery, address(0), address(0));
 
-        uint256 total = VAULT_SEED + ATTACKER_SEED;
+        // The attacker's seed is excluded from the bounty base: the bounty is 10% of the
+        // recovered PROTOCOL funds (VAULT_SEED), and the whitehat reclaims their own seed.
+        uint256 recovered = VAULT_SEED;
+        uint256 bounty = recovered * 1_000 / 10_000;
         assertEq(token.balanceOf(address(vault)), 0, "vault drained");
-        assertEq(token.balanceOf(recovery), total * 9_000 / 10_000, "90% returned to protocol");
-        assertEq(token.balanceOf(whitehat), total * 1_000 / 10_000, "10% bounty to whitehat");
+        assertEq(token.balanceOf(recovery), recovered - bounty, "90% of recovered returned to protocol");
+        assertEq(token.balanceOf(whitehat), bounty + ATTACKER_SEED, "bounty + reclaimed seed to whitehat");
     }
 }


### PR DESCRIPTION
The exploit deposits its own seed to drive the reentrancy, so the drained balance is the vault's funds plus that seed. The settlement computed the bounty on the full balance, which earned a bounty on the attacker's own seed: a "10%" bounty netted the whitehat ~1% of the protocol's funds.

Compute the bounty on recovered protocol funds only (total - SEED_AMOUNT). The protocol gets recovered - bounty back; the whitehat keeps the bounty plus the reclaimed seed. A 1000-token vault now settles to 900 returned, 100 bounty, 100 seed reclaimed.

The attack scripts derive the displayed split from the rule rather than post-attack balances, since RECOVERY_ADDRESS and the deploying wallet are the same address in the quickstart.